### PR TITLE
Sets default value of fields with type 'boolean' to false instead of nil

### DIFF
--- a/lib/databasedotcom/sobject/sobject.rb
+++ b/lib/databasedotcom/sobject/sobject.rb
@@ -17,7 +17,7 @@ module Databasedotcom
           if field['type'] =~ /(picklist|multipicklist)/ && picklist_option = field['picklistValues'].find { |p| p['defaultValue'] }
             self.send("#{field["name"]}=", picklist_option["value"])
           elsif field['type'] =~ /boolean/
-            self.send("#{field["name"]}=", field["defaultValue"])
+            self.send("#{field["name"]}=", field["defaultValue"] || false)
           else
             self.send("#{field["name"]}=", field["defaultValueFormula"])
           end


### PR DESCRIPTION
Right now the default value for fields of type "boolean" will be `nil` if `field["defaultValue"]` is unset.

If we attempt to persist a Sobject to salesforce and that Sobject has a boolean field with a nil value, salesforce will reject the request with a `"value not of require type error"`: it expects the boolean to be either `true` or `false` and won't accept `nil`. 

This PR makes is so that the default value for a boolean fields will get set to false in cases where it was previously getting set to nil
